### PR TITLE
Fix bug that Number::Rational<T>(0, 0) crash

### DIFF
--- a/include/rational.h
+++ b/include/rational.h
@@ -148,6 +148,10 @@ namespace Number
 
 	public:  // TODO
 		static Type gcd(Type a, Type b) {
+			if (a == 0 && b == 0)
+				return 0;
+			a = std::abs(a);
+			b = std::abs(b);
 			while (b != 0) {
 				a = a % b;
 				std::swap(a, b);

--- a/include/rational.h
+++ b/include/rational.h
@@ -137,19 +137,22 @@ namespace Number
 	private:
 		Rational& initialize(const Type &num, const Type &den) {
 			Type g = gcd(num, den);
-			_numerator = num / g;
-			_denominator = den / g;
-			if (_denominator < 0) {
-				_denominator = -_denominator;
-				_numerator = -_numerator;
+			if (num == 0 && den == 0) {
+				_numerator = _denominator = 0;
+			}
+			else {
+				_numerator = num / g;
+				_denominator = den / g;
+				if (_denominator < 0) {
+					_denominator = -_denominator;
+					_numerator = -_numerator;
+				}
 			}
 			return *this;
 		}
 
 	public:  // TODO
 		static Type gcd(Type a, Type b) {
-			if (a == 0 && b == 0)
-				return 0;
 			a = std::abs(a);
 			b = std::abs(b);
 			while (b != 0) {


### PR DESCRIPTION
modified the gcd to handle the cases where the parameters are all 0 orthe parameters are less than 0 correctly